### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -9,7 +9,7 @@
 ###
 
 
-Stepper KEYWORD1  Stepper
+Stepper	KEYWORD1	Stepper
 ####################################
 # Methods and Functions (KEYWORD2)
 #######################################
@@ -27,7 +27,7 @@ setMaxSpeed	KEYWORD2
 
 setMotorMode	KEYWORD2
 
-reverse		KEYWORD2
+reverse	KEYWORD2
 
 setImpulseTime	KEYWORD2
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords